### PR TITLE
Update why.mdx - formatting last sub-bullet

### DIFF
--- a/docs/src/content/docs/why.mdx
+++ b/docs/src/content/docs/why.mdx
@@ -109,6 +109,6 @@ This is a common question, and the answer lies in the benefits of using a Servic
 -   **Support for Advanced Patterns**: A service bus allows you to implement more advanced architectural patterns like:
     -   _Saga Orchestration_: Managing distributed transactions and workflows by coordinating multiple services or operations through a central mechanism.
     -   _Message Replay_: Replaying past events to rebuild state or debug issues.
-        \_ _Retry Policies_: Implementing automatic retries for operations that might fail due to transient issues, improving the resilience of your application.
+    -   _Retry Policies_: Implementing automatic retries for operations that might fail due to transient issues, improving the resilience of your application.
 
 </Aside>


### PR DESCRIPTION
I think the intent was to have `Retry Policies` be its own bullet point under `Support for Advanced Patterns` on [this page](https://missive-js.github.io/missive.js/why/)

| Q            | A      |
| ------------ | ------ |
| Bug fix?     | no |
| New feature? | no |
| BC breaks?   | no |
| Fixed issues | no   |

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
