### PR TITLE
Add links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Missive JS](https://github.com/Missive-js/missive.js)
+# [Missive JS](https://missive-js.github.io/missive.js)
 
 ## [![CI](https://github.com/missive-js/missive.js/actions/workflows/main-ci.yaml/badge.svg?branch=main)](https://github.com/Missive-js/missive.js/actions/workflows/main-ci.yaml) [![Deploy Docs](https://github.com/missive-js/missive.js/actions/workflows/deploy-to-pages.yaml/badge.svg?branch=main)](https://github.com/Missive-js/missive.js/actions/workflows/deploy-to-pages.yaml) [![Install size](https://packagephobia.com/badge?p=missive.js)](https://packagephobia.com/result?p=missive.js) ![Tree shaking](https://badgen.net/bundlephobia/tree-shaking/missive.js) ![Minizipped size](https://badgen.net/bundlephobia/minzip/missive.js)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Missive JS
+# [Missive JS](https://github.com/Missive-js/missive.js)
 
-## ![Main](https://github.com/missive-js/missive.js/actions/workflows/main-ci.yaml/badge.svg?branch=main) ![Main](https://github.com/missive-js/missive.js/actions/workflows/deploy-to-pages.yaml/badge.svg?branch=main) [![Install size](https://packagephobia.com/badge?p=missive.js)](https://packagephobia.com/result?p=missive.js) ![Tree shaking](https://badgen.net/bundlephobia/tree-shaking/missive.js) ![Minizipped size](https://badgen.net/bundlephobia/minzip/missive.js)
+## [![CI](https://github.com/missive-js/missive.js/actions/workflows/main-ci.yaml/badge.svg?branch=main)](https://github.com/Missive-js/missive.js/actions/workflows/main-ci.yaml) [![Deploy Docs](https://github.com/missive-js/missive.js/actions/workflows/deploy-to-pages.yaml/badge.svg?branch=main)](https://github.com/Missive-js/missive.js/actions/workflows/deploy-to-pages.yaml) [![Install size](https://packagephobia.com/badge?p=missive.js)](https://packagephobia.com/result?p=missive.js) ![Tree shaking](https://badgen.net/bundlephobia/tree-shaking/missive.js) ![Minizipped size](https://badgen.net/bundlephobia/minzip/missive.js)
 
 The Service Bus that you needed!
 


### PR DESCRIPTION
Current doc is missing link for the H1, CI, and Deploy Docs section. 

Added them as I see fit.

| Q            | A      |
| ------------ | ------ |
| Bug fix?     | yes |
| New feature? | no |

